### PR TITLE
fix: wrong highlight after a change operation

### DIFF
--- a/lua/tiny-glimmer/init.lua
+++ b/lua/tiny-glimmer/init.lua
@@ -128,7 +128,7 @@ function M.setup(options)
 	vim.api.nvim_create_autocmd("TextYankPost", {
 		group = animation_group,
 		callback = function()
-			if not M.config.enabled or vim.v.event.operator == "d" then
+			if not M.config.enabled or vim.v.event.operator == "d" or vim.v.event.operator == "c" then
 				return
 			end
 


### PR DESCRIPTION
Hi ! 
Very nice plugin. I noticed a weird behavior when using a change operator (\<c\>, \<s\>, etc). It animates the place where the text used to be (but now deleted by using a change operator).
I fixed it by adding a condition that if the operator of the event "TextYankPost" is equal to "c" then return without any animation.