### PR TITLE
fix: end of line calculation

### DIFF
--- a/lua/tiny-glimmer/animation.lua
+++ b/lua/tiny-glimmer/animation.lua
@@ -102,7 +102,7 @@ local function calculate_end_position(self, line_content, line_index, animation_
 	end
 
 	if self.yank_type:lower() == "v" then
-		if line_index == 1 and self.selection.end_line == self.selection.start_line then
+		if line_index == 1 then
 			end_position = (self.selection.start_col + #line_content) * animation_progress
 		elseif line_index == #self.selection then
 			end_position = (self.selection.start_col + #line_content) * animation_progress


### PR DESCRIPTION
I found a bug when yanking using the visual mod on multiple lines.
When starting the yank in a col after the first one it would not add the start_col offset to the computation of the end of the line.
In the following example if I yank starting at 2 and ending at 5 it would animate only 2, 3 and 5, forgetting the 4.
```
1234
5678
```
To fix that I removed a condition where the start_col offset is added only if the line index is 1 AND if the start_col and end_col are equals. I don't know why the second condition was there but removing it fixed the problem (maybe there's other cases where it is needed that I didn't think about).