### PR TITLE
feat: Add `LineAnimation` support

### DIFF
--- a/lua/tiny-glimmer/animation/factory.lua
+++ b/lua/tiny-glimmer/animation/factory.lua
@@ -17,6 +17,7 @@ AnimationFactory.__index = AnimationFactory
 local instance = nil
 local TextAnimation = require("tiny-glimmer.animation.premade.text")
 local RectangleAnimation = require("tiny-glimmer.animation.premade.rectangle")
+local LineAnimation = require("tiny-glimmer.animation.premade.line")
 
 function AnimationFactory.initialize(opts, effect_pool, animation_refresh)
 	if instance then
@@ -73,6 +74,14 @@ function AnimationFactory:create_rectangle_animation(animation_type, opts)
 	local effect = self:_begin_create_animation(animation_type, opts)
 
 	local animation = RectangleAnimation.new(effect, opts)
+
+	self:_create_animation(animation)
+end
+
+function AnimationFactory:create_line_animation(animation_type, opts)
+	local effect = self:_begin_create_animation(animation_type, opts)
+
+	local animation = LineAnimation.new(effect, opts)
 
 	self:_create_animation(animation)
 end

--- a/lua/tiny-glimmer/animation/premade/line.lua
+++ b/lua/tiny-glimmer/animation/premade/line.lua
@@ -1,0 +1,89 @@
+---@class LineAnimation
+---@field cursor_line_enabled boolean Whether to show special cursor line animation
+---@field cursor_line_color string|nil Hex color code for cursor line highlight
+---@field virtual_text_priority number Priority level for virtual text rendering
+---@field animation GlimmerAnimation Animation effect instance
+---@field old_msgarea vim.api.keyset.highlight
+local LineAnimation = {}
+LineAnimation.__index = LineAnimation
+
+local utils = require("tiny-glimmer.utils")
+local namespace = require("tiny-glimmer.namespace").tiny_glimmer_animation_ns
+local namespace_id_pool = require("tiny-glimmer.namespace_id_pool")
+local AnimationEffect = require("tiny-glimmer.glimmer_animation")
+
+--- Creates anew LineAnimation Instance
+---@param effect any The animiation effect implementation to use
+---aram opts table Configuration options
+---@return LineAnimation The created LineAnimation instance
+function LineAnimation.new(effect, opts)
+	local self = setmetatable({}, LineAnimation)
+
+	if not opts.base then
+		error("opts.base is required")
+	end
+
+	self.old_msgarea = utils.get_highlight("MsgArea")
+	self.virtual_text_priority = opts.virtual_text_priority or 128
+
+	local cursor_line_hl = utils.get_highlight("CursorLine").bg
+	local animation_opts = opts.base
+
+	self.cursor_line_enabled = false
+
+	if cursor_line_hl ~= nil and cursor_line_hl ~= "None" then
+		self.cursor_line_enabled = true
+		animation_opts = vim.tbl_extend("force", opts.base, {
+			overwrite_to_color = utils.int_to_hex(cursor_line_hl),
+		})
+	end
+	self.animation = AnimationEffect.new(effect, animation_opts)
+
+	return self
+end
+
+local function apply_hl(self, line, ns_id)
+	local line_index = self.animation.range.start_line
+	local hl_group = self.animation:get_hl_group()
+	if self.cursor_line_enabled then
+		local cursor_position = vim.api.nvim_win_get_cursor(0)
+
+		if cursor_position[1] - 1 == line_index then
+			hl_group = self.animation:get_overwrite_hl_group()
+		end
+	end
+
+	utils.set_extmark(line - 1, namespace, 0, {
+		id = ns_id,
+		end_col = 0,
+		hl_eol = true,
+		end_row = line,
+		hl_group = hl_group,
+		priority = self.virtual_text_priority,
+	})
+end
+
+function LineAnimation:start(refresh_interval_ms)
+	local length = self.animation.range.end_line - self.animation.range.start_line
+	local reserved_ids = namespace_id_pool.reserve_ns_ids(length)
+
+	self.animation:start(refresh_interval_ms, length or 1, {
+		on_update = function(update_progress)
+			vim.api.nvim_buf_clear_namespace(
+				0,
+				namespace,
+				self.animation.range.start_line,
+				self.animation.range.start_line + 1
+			)
+
+			for i = 1, length do
+				apply_hl(self, i + self.animation.range.start_line, reserved_ids[i])
+			end
+		end,
+		on_complete = function()
+			namespace_id_pool.release_ns_ids(reserved_ids)
+		end,
+	})
+end
+
+return LineAnimation

--- a/lua/tiny-glimmer/animation/premade/line.lua
+++ b/lua/tiny-glimmer/animation/premade/line.lua
@@ -3,7 +3,6 @@
 ---@field cursor_line_color string|nil Hex color code for cursor line highlight
 ---@field virtual_text_priority number Priority level for virtual text rendering
 ---@field animation GlimmerAnimation Animation effect instance
----@field old_msgarea vim.api.keyset.highlight
 local LineAnimation = {}
 LineAnimation.__index = LineAnimation
 
@@ -23,7 +22,6 @@ function LineAnimation.new(effect, opts)
 		error("opts.base is required")
 	end
 
-	self.old_msgarea = utils.get_highlight("MsgArea")
 	self.virtual_text_priority = opts.virtual_text_priority or 128
 
 	local cursor_line_hl = utils.get_highlight("CursorLine").bg

--- a/lua/tiny-glimmer/init.lua
+++ b/lua/tiny-glimmer/init.lua
@@ -28,6 +28,11 @@ M.config = {
 			paste_mapping = "p",
 			Paste_mapping = "P",
 		},
+		-- TODO: This is not exactly an 'override', where to place?
+		line = {
+			enabled = false,
+			default_animation = "fade",
+		},
 	},
 
 	default_animation = "fade",
@@ -226,6 +231,25 @@ function M.setup(options)
 			end,
 		})
 		vim.opt.hlsearch = false
+	end
+
+	if M.config.overwrite.line.enabled then
+		vim.api.nvim_create_autocmd({ "WinEnter", "CmdlineLeave" }, {
+			group = animation_group,
+			callback = function()
+				local pos = vim.api.nvim_win_get_cursor(0)
+				AnimationFactory.get_instance():create_line_animation(M.config.overwrite.line.default_animation, {
+					base = {
+						range = {
+							start_line = pos[1] - 1,
+							start_col = 0,
+							end_line = pos[1],
+							end_col = 0,
+						},
+					},
+				})
+			end,
+		})
 	end
 end
 


### PR DESCRIPTION
This change adds a new animation type called `line`. Unlike the existing `text` animation, this animation style does not depend on any content, meaning that is possible to highlight over any arbituary lines.
This animation types tries to mimic `pulasr.el`, an Emacs package that highlights the current line on certain events.

This PR also adds a new option to the config to enable line highlighting on on `WinLeave` and `CmdlineLeave`. 
**However**, this does not *really* fit in with the current config nor features since it is not overriding any default behavior.

I would understand if you would not like this feature to be *directly* supported, but I do believe that the `LineAnimation` should be kept so that a user can implement their own animations with it. (i.e. a mapping to flash their current line or to flash all git changes)

## Showcase

https://github.com/user-attachments/assets/9cbef84a-63eb-424e-8b71-836b0c7ba4d4

## Config
```lua
local tg = require("tiny-glimmer")
tg.setup({
  overwrite = {
    line = {
      enabled = true,
      default_animation = "fade",
    },
  },
  animations = {
    fade = {
      max_duration = 1000,
      min_duration = 1000,
      easing = "linear",
      chars_for_max_duration = 10,
    },
  },
})

tg.change_hl("all", { from_color = "DiffDelete", to_color = "CursorLine" })
```
