### PR TITLE
Allow `paste_mapping` to be `"<Plug(...)>"`

### DIFF
--- a/lua/tiny-glimmer/overwrite/paste.lua
+++ b/lua/tiny-glimmer/overwrite/paste.lua
@@ -37,7 +37,8 @@ local function animate_paste(opts, mode)
 		end
 	end
 
-	vim.fn.feedkeys(vim.v.count1 .. cmd, "n")
+	local keys = vim.api.nvim_replace_termcodes(vim.v.count1 .. cmd, true, true, true)
+	vim.api.nvim_feedkeys(keys, "n", false)
 	restore_paste_mode(paste_mode)
 
 	vim.schedule(function()


### PR DESCRIPTION
Thanks for making this awesome plugin!

I tried to get this working together with [yanky.nvim](https://github.com/gbprod/yanky.nvim/), which I mainly use for its "paste ring".

I tried doing something like this, but with no success:

```lua
{
  overwrite = {
    paste = {
      paste_mapping = '<Plug>(YankyPutAfter)',
    },
  },
}
```

My PR fixes this issue.
